### PR TITLE
MICAH - Add working paths, functional local search by tags, Datastore Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
  
 ## Getting started ##
+`cd my-app`
 To install: `npm install`
 
-To run server + webpack: `npm run start`
+To run server: `npm start`
+
+See instruction in `my-app/README.md`
 
 ## Notes ##
 

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -9,7 +9,6 @@ import DataStore from './DataStore.jsx';
 import {
   BrowserRouter as Router,
   Route,
-  Link,
   withRouter,
 } from 'react-router-dom'
 
@@ -131,11 +130,11 @@ class App extends Component {
 
 const AppBox = withRouter(App);
 
-const BasicExample = () => (
+const FullApp = () => (
   <Router>
     <div>
       <AppBox/>
     </div>
   </Router>
 )
-export default BasicExample
+export default FullApp

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,17 +1,15 @@
 import React, { Component } from 'react';
 import './App.css';
-import persons from './ConstData/persons.js';
-import tags from './ConstData/tags.js';
 import Omnibox from './Omnibox/Omnibox.jsx';
-import PersonBox from './Person/Person.jsx';
-import SearchBox from './Search/Search.jsx';
+import Person from './Person/Person.jsx';
+import Search from './Search/Search.jsx';
 import Home from './Home/Home.js';
+import DataStore from './DataStore.jsx';
 
 import {
   BrowserRouter as Router,
   Route,
   Link,
-  Redirect,
   withRouter,
 } from 'react-router-dom'
 
@@ -60,14 +58,50 @@ class App extends Component {
     firebase.initializeApp(config);
   */
     this.state = { 
+      tags:[],
+      persons:[],
+      user:'default'
     };
+    DataStore.getAllTags()
+    .then((tags) =>{
+      this.setState({tags:tags});
+    });
+    DataStore.getAllPersons()
+    .then((persons) =>{
+      this.setState({persons:persons});
+    });
     this.addThing = this.addThing.bind(this);
     this.setPerson = this.setPerson.bind(this);
     this.setTag = this.setTag.bind(this);
   }
 
   addThing = thing => {
-    console.log('adding thing: ' + thing);
+    // If you are in person mode the new thing will be a tag
+    // If you are in search mode you can't add new things
+    // If you are in home mode a new thing is a person
+    var path = this.props.location.pathname.split("/");
+    if (path[1] === ""){
+      DataStore.addPersonByName(thing)
+      .then((id)=>{
+        this.props.history.push('/person/'+id);
+        DataStore.getAllPersons()
+        .then((persons) =>{
+          this.setState({persons:persons});
+        });
+      });
+    } else if (path[1] === "person") {
+      var subject = path[2];
+      var originator = this.state.user;
+      DataStore.addTag(subject, thing, originator)
+      .then((id)=>{
+        console.log("added tag: " + id);
+        DataStore.getAllTags()
+        .then((tags) =>{
+          this.setState({tags:tags});
+        });
+      });
+      console.log("creating and adding tag " + thing + " to " + path[2]);
+    } 
   }
 
   setPerson = person => {
@@ -76,8 +110,26 @@ class App extends Component {
   }
 
   setTag = tag => {
-    console.log('set tag: ' + tag.label);
-    this.props.history.push('/search/'+tag.id);
+    //If you are in person mode add that tag to a person
+    //If you are in home mode start searching
+    //If you are in search mode add that tag to the search
+    var path = this.props.location.pathname.split("/");
+    if (path[1] === ""){
+      this.props.history.push('/search/'+tag.id);
+    } else if (path[1]==="person") {
+      // Add Tag to person
+      console.log("adding " + tag.label + " to " + path[2]);
+    } else if (path[1]==="search") {
+      if (path.length === 2 || path[2] === "") {
+        var prettySlash = '/';
+        if (this.props.location.pathname.slice(-1)===prettySlash) {
+          prettySlash="";
+        }
+        this.props.history.push(this.props.location.pathname+ prettySlash + tag.label.replace(/[^A-Z0-9]/ig, "_"));
+      } else if (path.length === 3) {
+        this.props.history.push(this.props.location.pathname+"+"+tag.label.replace(/[^A-Z0-9]/ig, "_"));
+      }      
+    }
   }
 
 
@@ -86,29 +138,33 @@ class App extends Component {
       <div>
         <div id="firebaseui-auth-container"></div>
         <Omnibox 
-          persons={persons} 
-          tags={tags}
+          persons={this.state.persons} 
+          tags={this.state.tags}
           addThing={this.addThing}
           setPerson={this.setPerson}
           setTag={this.setTag} 
         />
-
+        <Route exact path="/" component={Home}/>
+        <Route path="/topics" component={Topics}/>
+        <Route path="/person/:personId" 
+               render={(props)=><Person {...props.match.params} 
+                                 tags={this.state.tags}
+                                 persons={this.state.persons}/>}/>
+        <Route path="/search/:searchString" 
+               render={(props)=><Search {...props.match.params} 
+                                 tags={this.state.tags}
+                                 persons={this.state.persons}/>}/>
       </div>
     )
   }
 }
 
-const AppWithRouter = withRouter(App);
+const AppBox = withRouter(App);
 
 const BasicExample = () => (
   <Router>
     <div>
-      <AppWithRouter/>
-      <hr/>
-        <Route exact path="/" component={Home}/>
-        <Route path="/topics" component={Topics}/>
-        <Route path="/person" component={PersonBox}/>
-        <Route path="/search" component={SearchBox}/>
+      <AppBox/>
     </div>
   </Router>
 )

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -35,7 +35,7 @@ class App extends Component {
     };
     DataStore.getAllTags()
     .then((tags) =>{
-      this.setState({tags:tags});
+      this.setState({tags});
     });
     DataStore.getAllPersons()
     .then((persons) =>{

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -14,34 +14,6 @@ import {
 } from 'react-router-dom'
 
 
-
-const Topics = ({ match }) => (
-  <div>
-    <h2>Topics</h2>
-    <ul>
-      <li>
-        <Link to={`${match.url}/rendering`}>
-          Rendering with React
-        </Link>
-      </li>
-      <li>
-        <Link to={`${match.url}/components`}>
-          Components
-        </Link>
-      </li>
-      <li>
-        <Link to={`${match.url}/props-v-state`}>
-          Props v. State
-        </Link>
-      </li>
-    </ul>
-
-    <Route exact path={match.path} render={() => (
-      <h3>Please select a topic.</h3>
-    )}/>
-  </div>
-)
-
 class App extends Component {
   constructor(props) {
     super(props);
@@ -94,7 +66,6 @@ class App extends Component {
       var originator = this.state.user;
       DataStore.addTag(subject, thing, originator)
       .then((id)=>{
-        console.log("added tag: " + id);
         DataStore.getAllTags()
         .then((tags) =>{
           this.setState({tags:tags});
@@ -145,7 +116,6 @@ class App extends Component {
           setTag={this.setTag} 
         />
         <Route exact path="/" component={Home}/>
-        <Route path="/topics" component={Topics}/>
         <Route path="/person/:personId" 
                render={(props)=><Person {...props.match.params} 
                                  tags={this.state.tags}

--- a/my-app/src/ConstData/persons.js
+++ b/my-app/src/ConstData/persons.js
@@ -1,18 +1,18 @@
 export default [
   {
-    id: '1',
+    id: 'Adrienne_Tran',
     name: 'Adrienne Tran'
   },
   {
-    id: '2',
+    id: 'Micah_Catlin',
     name: 'Micah Catlin'
   },
   {
-    id: '3',
+    id: 'Benjamin_Reinhardt',
     name: 'Benjamin Reinhardt'
   },
     {
-    id: '4',
+    id: 'Sasha_Sheng',
     name: 'Sasha Sheng'
   }
 ];

--- a/my-app/src/ConstData/tags.js
+++ b/my-app/src/ConstData/tags.js
@@ -1,104 +1,104 @@
 export default [
   {
-    id: 'a',
-    subject: '1',
-    originator: '3',
+    id: 'PM0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'PM',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'b',
-    subject: '1',
-    originator: '3',
+    id: 'Brown0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'Brown',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'c',
-    subject: '1',
-    originator: '3',
+    id: 'Tesla0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'Tesla',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'd',
-    subject: '1',
-    originator: '3',
+    id: 'LinkedIn0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'LinkedIn',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'e',
-    subject: '1',
-    originator: '3',
+    id: 'Climbing0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'Climbing',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'f',
-    subject: '1',
-    originator: '3',
+    id: 'Loc:SF0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'Loc:SF',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'g',
-    subject: '1',
-    originator: '3',
+    id: 'FriendForce0',
+    subject: 'Adriennne_Tran',
+    originator: 'Benjamin_Reinhardt',
     label: 'FriendForce',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'h',
-    subject: '2',
-    originator: '3',
+    id: 'Loc:SF1',
+    subject: 'Micah_Catlin',
+    originator: 'Benjamin_Reinhardt',
     label: 'Loc:SF',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'i',
-    subject: '2',
-    originator: '3',
+    id: 'FriendForce0',
+    subject: 'Micah_Catlin',
+    originator: 'Benjamin_Reinhardt',
     label: 'FriendForce',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'j',
-    subject: '2',
-    originator: '3',
+    id: 'Kansas0',
+    subject: 'Micah_Catlin',
+    originator: 'Benjamin_Reinhardt',
     label: 'Kansas',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'k',
-    subject: '2',
-    originator: '3',
+    id: 'Bikes0',
+    subject: 'Micah_Catlin',
+    originator: 'Benjamin_Reinhardt',
     label: 'Bikes',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'l',
-    subject: '2',
-    originator: '3',
+    id: 'Loc:Mission0',
+    subject: 'Micah_Catlin',
+    originator: 'Benjamin_Reinhardt',
     label: 'Loc:Mission',
     timestamp: '02-19-2018',
     publicity: 'public'
   },
   {
-    id: 'm',
-    subject: '2',
-    originator: '3',
+    id: 'Beer0',
+    subject: 'Micah_Catlin',
+    originator: 'Benjamin_Reinhardt',
     label: 'Beer',
     timestamp: '02-19-2018',
     publicity: 'public'

--- a/my-app/src/DataStore.jsx
+++ b/my-app/src/DataStore.jsx
@@ -1,8 +1,23 @@
-import React from 'react';
+
 //Remove these when we're done with constant data
 import persons from './ConstData/persons.js';
 import tags from './ConstData/tags.js';
 
+export const uuid = foo => {
+  // Get a random uuid
+  // This is temporary until the database is hooked up
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  )
+}
+
+export const nameToId = name => {
+  return name.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
+}
+
+export const tagToId = tag => {
+  return tag.label.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
+}
 
 class DataStore {
   constructor(){
@@ -44,6 +59,13 @@ class DataStore {
      * @param person {string Name} with populated fields
      * @return {Promise} promise resolves when person successfully added
      */
+     var id = nameToId(name);
+     var person = {
+        id:id,
+        name:name
+      };
+      this._persons.push(person);
+     return Promise.resolve(person.id);
   }
 
   addPerson(person){
@@ -55,7 +77,7 @@ class DataStore {
     return Promise.resolve(this._persons.push(person));
   }
 
-  addTag(subject, label, publicity='public', originator=''){
+  addTag(subject, label, originator, publicity='public'){
     /** NOT IMPLEMENTED
      * Adds a Tag object to the Datastore
      * @param subject {string->id} subject of the tag
@@ -66,16 +88,18 @@ class DataStore {
           defaults to the active user
      * @return {Promise} promise resolves when tag successfully added
      */
+     var tag = {
+      id:'',
+      subject:subject,
+      label:label,
+      publicity:publicity,
+      originator:originator,
+     }
+     tag.id = tagToId(tag);
+     this._tags.push(tag);
+     return Promise.resolve(tag.id);
   }
 
-  addTag(tag){
-    /**
-     * Adds a Tag object to the Datastore
-     * @param tag {Tag} with populated fields
-     * @return {Promise} promise resolves when tag successfully added
-     */
-    return Promise.resolve(this._tags.push(tag));
-  }
 
   deleteTag(id) {
     /** NOT IMPLEMENTED
@@ -118,7 +142,7 @@ class DataStore {
      * @return {Promise} promise for a {Person Array} of Persons
      *          with the given name
      */
-    return Promise.resolve(this._persons.filter(d => d.name == name));
+    return Promise.resolve(this._persons.filter(d => d.name === name));
   }
 
   getAllPersons(){
@@ -144,7 +168,7 @@ class DataStore {
      * @return {Promise} promise for a {Tag Array} of Tags
      *          with the given subject
      */
-    return Promise.resolve(this._tags.filter(tag => tag.subject == id));
+    return Promise.resolve(this._tags.filter(tag => tag.subject === id));
   }
 
   /* test code */

--- a/my-app/src/DataStore.jsx
+++ b/my-app/src/DataStore.jsx
@@ -3,20 +3,20 @@
 import persons from './ConstData/persons.js';
 import tags from './ConstData/tags.js';
 
-export const nameToId = name => {
-  return name.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
-}
-
-export const tagToId = tag => {
-  return tag.label.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
-}
-
 class DataStore {
   constructor(){
      // TODO: Change what gets loaded 
      this._data = [];
      this.loadExternalPersons(persons);
      this.loadExternalTags(tags);
+  }
+
+  _nameToId(name) {
+    return name.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
+  } 
+
+  _tagToId(tag) {
+    return tag.label.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
   }
 
   resetData(){
@@ -51,7 +51,7 @@ class DataStore {
      * @param person {string Name} with populated fields
      * @return {Promise} promise resolves when person successfully added
      */
-     var id = nameToId(name);
+     var id = this._nameToId(name);
      var person = {
         id:id,
         name:name
@@ -87,7 +87,7 @@ class DataStore {
       publicity:publicity,
       originator:originator,
      }
-     tag.id = tagToId(tag);
+     tag.id = this._tagToId(tag);
      this._tags.push(tag);
      return Promise.resolve(tag.id);
   }

--- a/my-app/src/DataStore.jsx
+++ b/my-app/src/DataStore.jsx
@@ -7,6 +7,7 @@ export const uuid = foo => {
   // Get a random uuid
   // This is temporary until the database is hooked up
   return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+  // eslint-disable-next-line
     (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
   )
 }

--- a/my-app/src/DataStore.jsx
+++ b/my-app/src/DataStore.jsx
@@ -3,15 +3,6 @@
 import persons from './ConstData/persons.js';
 import tags from './ConstData/tags.js';
 
-export const uuid = foo => {
-  // Get a random uuid
-  // This is temporary until the database is hooked up
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-  // eslint-disable-next-line
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export const nameToId = name => {
   return name.replace(/[^A-Z0-9]/ig, "_") + crypto.getRandomValues(new Uint8Array(1));
 }

--- a/my-app/src/Omnibox/Omnibox.jsx
+++ b/my-app/src/Omnibox/Omnibox.jsx
@@ -4,6 +4,25 @@ import Autosuggest from 'react-autosuggest';
 
 
 //const focusInputOnSuggestionClick = !isMobile.any;
+const uniqLabelFast = a => {
+  /**
+   * Quickly makes a list tags without repeating labels
+   * @param a {[Tag]} list of tags
+   */
+
+    var seen = {};
+    var out = [];
+    var len = a.length;
+    var j = 0;
+    for(var i = 0; i < len; i++) {
+         var item = a[i].label;
+         if(seen[item] !== 1) {
+               seen[item] = 1;
+               out[j++] = a[i];
+         }
+    }
+    return out;
+}
 
 const escapeRegexCharacters = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -50,7 +69,7 @@ export default class OmniBox extends Component {
   }
 
   componentWillMount = value => {
-    var options = this.props.persons.concat(this.props.tags);
+    var options = this.props.persons.concat(uniqLabelFast(this.props.tags));
     this.setState({
       options: options
     });
@@ -58,7 +77,7 @@ export default class OmniBox extends Component {
 
   componentWillReceiveProps = new_props => {
     // Update lists of things when props change
-     var options = this.props.persons.concat(new_props.tags);
+    var options = new_props.persons.concat(uniqLabelFast(new_props.tags));
     this.setState({
       options: options
     });

--- a/my-app/src/Omnibox/Omnibox.jsx
+++ b/my-app/src/Omnibox/Omnibox.jsx
@@ -21,6 +21,7 @@ const uniqLabelFast = a => {
                out[j++] = a[i];
          }
     }
+    console.log(out);
     return out;
 }
 

--- a/my-app/src/Person/Person.jsx
+++ b/my-app/src/Person/Person.jsx
@@ -3,23 +3,15 @@ import {
   Route,
 } from 'react-router-dom'
 
-class Person extends Component {
-  constructor({match}) {
+export default class Person extends Component {
+  constructor() {
     super();
-    this.match = match;
   }
   render() {
     return(
       <div>
-        <h2>Person: {this.match.params.personId}</h2>
+        <h2>Person: {this.props.personId}</h2>
       </div>
     );
   }
 }
-
-const PersonBox = ({ match }) => (
-    <Route path={`${match.path}/:personId`} component={Person}/>
-
-)
-
-export default PersonBox

--- a/my-app/src/Person/Person.jsx
+++ b/my-app/src/Person/Person.jsx
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
-import {
-  Route,
-} from 'react-router-dom'
 
 export default class Person extends Component {
+  // eslint-disable-next-line
   constructor() {
     super();
   }

--- a/my-app/src/Search/Search.jsx
+++ b/my-app/src/Search/Search.jsx
@@ -2,9 +2,7 @@ import React, { Component } from 'react';
 
 const getSearchLabels =(searchString) => {
   var labels = searchString.split("+");
-  var formattedLabels = [];
-  labels.forEach(label => {
-    label.replace("%"," "); formattedLabels.push(label);});
+  const formattedLabels = labels.map(label => label.replace("%", " "))
   return formattedLabels;
 }
 

--- a/my-app/src/Search/Search.jsx
+++ b/my-app/src/Search/Search.jsx
@@ -1,34 +1,15 @@
 import React, { Component } from 'react';
-import {
-  Route,
-} from 'react-router-dom'
 
 const getSearchLabels =(searchString) => {
-  return searchString.split("+");
+  var labels = searchString.split("+");
+  var formattedLabels = [];
+  labels.forEach(label => {
+    label.replace("%"," "); formattedLabels.push(label);});
+  return formattedLabels;
 }
-
-const uniqIdFast = a => {
-  /**
-   * Quickly makes a list tags without repeating labels
-   * @param a {[Tag]} list of tags
-   */
-
-    var seen = {};
-    var out = [];
-    var len = a.length;
-    var j = 0;
-    for(var i = 0; i < len; i++) {
-         var item = a[i];
-         if(seen[item] !== 1) {
-               seen[item] = 1;
-               out[j++] = item;
-         }
-    }
-    return out;
-}
-
 
 export default class Search extends Component {
+  // eslint-disable-next-line
   constructor() {
     super();
   }
@@ -38,27 +19,31 @@ export default class Search extends Component {
     var matchingTags = [];
     var potentialMatchingPersons = [];
     var matchingPersons = [];
-    for (var i = 0; i < searchLabels.length; i++) {
-      matchingTags.push(this.props.tags.filter(tag => 
-        {tag.label === searchLabels[i]}));
-    }
 
-    console.log(matchingTags);
     for (var i = 0; i < searchLabels.length; i++) {
-      potentialMatchingPersons.push(
-        matchingTags[i].map(tag => tag.subject));
+          // eslint-disable-next-line
+      var tags = this.props.tags.filter(tag => 
+        tag.label === searchLabels[i]);
+      matchingTags.push(tags);
     }
-    console.log(potentialMatchingPersons);
+    matchingTags.forEach(tags => {
+      potentialMatchingPersons.push(
+        tags.map(tag => tag.subject));
+    });
     // Persons must have all search terms to pass (for now)
-    potentialMatchingPersons[0].forEach(personId => {
-      var num_matches = potentialMatchingPersons.filter(personList => {
-        personList.indexOf(personId) > -1
-      });
-      if (num_matches === searchLabels.length) {
-        matchingPersons.push(personId);
+    potentialMatchingPersons[0].forEach(person => {
+      var match = true;
+      for (var i = 0; i < potentialMatchingPersons.length; i++) {
+        if (potentialMatchingPersons[i].indexOf(person) < 0) {
+          match = false;
+          break;
+        }
+      }
+      if (match === true) {
+        matchingPersons.push(person);
       }
     });
-    return potentialMatchingPersons;
+    return matchingPersons;
   }
 
 

--- a/my-app/src/Search/Search.jsx
+++ b/my-app/src/Search/Search.jsx
@@ -3,23 +3,75 @@ import {
   Route,
 } from 'react-router-dom'
 
-class Search extends Component {
-  constructor({match}) {
+const getSearchLabels =(searchString) => {
+  return searchString.split("+");
+}
+
+const uniqIdFast = a => {
+  /**
+   * Quickly makes a list tags without repeating labels
+   * @param a {[Tag]} list of tags
+   */
+
+    var seen = {};
+    var out = [];
+    var len = a.length;
+    var j = 0;
+    for(var i = 0; i < len; i++) {
+         var item = a[i];
+         if(seen[item] !== 1) {
+               seen[item] = 1;
+               out[j++] = item;
+         }
+    }
+    return out;
+}
+
+
+export default class Search extends Component {
+  constructor() {
     super();
-    this.match = match;
   }
+
+  getMatchingPersons = () => {
+    var searchLabels = getSearchLabels(this.props.searchString);
+    var matchingTags = [];
+    var potentialMatchingPersons = [];
+    var matchingPersons = [];
+    for (var i = 0; i < searchLabels.length; i++) {
+      matchingTags.push(this.props.tags.filter(tag => 
+        {tag.label === searchLabels[i]}));
+    }
+
+    console.log(matchingTags);
+    for (var i = 0; i < searchLabels.length; i++) {
+      potentialMatchingPersons.push(
+        matchingTags[i].map(tag => tag.subject));
+    }
+    console.log(potentialMatchingPersons);
+    // Persons must have all search terms to pass (for now)
+    potentialMatchingPersons[0].forEach(personId => {
+      var num_matches = potentialMatchingPersons.filter(personList => {
+        personList.indexOf(personId) > -1
+      });
+      if (num_matches === searchLabels.length) {
+        matchingPersons.push(personId);
+      }
+    });
+    return potentialMatchingPersons;
+  }
+
+
   render() {
+    var searchLabels = getSearchLabels(this.props.searchString);
+    var matchingPersons = this.getMatchingPersons();
     return(
       <div>
-        <h2>Search: {this.match.params.searchString}</h2>
+        <h2>Searching for matches to tags: </h2>
+        <h4>{searchLabels}</h4>
+        <h2>Resulting People</h2>
+        <h4>{matchingPersons}</h4>
       </div>
     );
   }
 }
-
-const SearchBox = ({ match }) => (
-    <Route path={`${match.path}/:searchString`} component={Search}/>
-
-)
-
-export default SearchBox

--- a/my-app/src/index.js
+++ b/my-app/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import BasicExample from './App';
+import FullApp from './App';
 import registerServiceWorker from './registerServiceWorker';
 
-ReactDOM.render(<BasicExample />, document.getElementById('root'));
+ReactDOM.render(<FullApp />, document.getElementById('root'));
 registerServiceWorker();


### PR DESCRIPTION
Lots of different things (I need to get better at separating functions into different PRS)
- Integrates `DataStore` into the App so everything is managed through the `DataStore` API
- Changes the ID convention on Tags and People: before it was random uuids - now it is human readable: this will make everything easier going forward
- Adds logic around what should happen based off of which state the app is in
- Makes all the paths work:
`/search/label1+label2+label3` goes into search mode for all those labels
`/person/personID`   goes into person mode and lets you add tags